### PR TITLE
Products/index page

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -8,6 +8,7 @@
 
 /* その他のカスタムCSSやSCSSがあれば、ここに追記またはインポート */
 @import "./posts.css";
+@import "./products.css";
 
 /* コンテンツのカード化 */
 .my-card {

--- a/app/assets/stylesheets/products.css
+++ b/app/assets/stylesheets/products.css
@@ -1,0 +1,142 @@
+/* -------------------------------------- */
+/* pruducts/indexページ */
+/* 1. 商品リスト全体のレスポンシブなグリッド */
+.product-list-container {
+    /* モバイル（デフォルト）: 縦一列 */
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 8px; /* カードの間隔 */
+    list-style: none; /* ulのデフォルトの黒点を消す */
+    padding: 0;
+}
+
+/* PC幅以上 (md: 768px 以上を想定) */
+@media (min-width: 768px) {
+    .product-list-container {
+        /* PC: 3列表示 */
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
+/* 2. 個別カードのスタイリング */
+.product-card {
+    background-color: white;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1); /* shadow-md に相当 */
+    border-radius: 0.5rem; /* rounded-lg に相当 */
+    overflow: hidden;
+}
+
+/* カード内の画像エリアと情報エリアのレイアウト */
+.product-card-inner {
+    /* モバイル（デフォルト）: 縦並び */
+    display: flex;
+    flex-direction: row;
+}
+
+/* 幅が狭い画面では縦並びに戻す */
+@media (max-width: 480px) {
+  .product-card-inner {
+    flex-direction: column;
+  }
+}
+
+/* PC幅以上 (md: 768px 以上を想定) */
+@media (min-width: 768px) {
+    .product-card {
+        min-height: 300px;
+    }
+
+    .product-card-inner {
+        /* PC: 横並び */
+        flex-direction: row;
+        height: 100%; /* ★PCでのみ高さを親（.product-card）に合わせる */
+    }
+}
+
+/* 3. 画像エリアと縦横比 (4:3) の設定 */
+.product-image-area {
+    width: 50%; /* モバイルでは全幅 */
+    position: relative;
+    /* 縦横比 4:3 の設定 */
+    padding-bottom: 75%; /* (3 / 4) * 100% = 75% */
+    overflow: hidden;
+    flex-shrink: 0;
+}
+
+.product-image-area .product-image {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+/* PC幅以上 (md: 768px 以上を想定) */
+@media (min-width: 768px) {
+    .product-image-area {
+        /* PC: 幅を親要素の50%に設定 */
+        width: 50%;
+        /* 縦横比の計算は親要素が制御するため、padding-bottomをリセットまたは調整 */
+        padding-bottom: 0; /* flex-rowになったら高さを親に依存させる */
+        height: 100%;
+    }
+}
+
+/* 4. タイトル&レーダーチャート */
+.product-info-area {
+    padding: 16px; /* p-4 に相当 */
+    width: 100%; /* モバイルでは全幅 */
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    flex-shrink: 1; /* 縮小を許可し、スペースを調整 */
+    min-width: 0; 
+}
+
+/* レーダーチャートのコンテナを中央寄せに */
+.new-pentagon-radar-chart-container {
+  display: flex;               /* flexboxを使う */
+  justify-content: center;     /* 水平方向に中央寄せ */
+  align-items: center;         /* 垂直方向にも中央寄せ（お好みで） */
+  width: 100%;
+  margin-top: 8px;             /* 少し余白を入れると見やすい */
+}
+
+.radar-chart {
+  width: 160px !important;
+  height: 160px !important;
+  display: block; /* インライン要素の左寄せを防ぐ */
+  max-width: 100%; /* はみ出し防止 */
+}
+
+/* レーダーチャートのコンテナに最大幅を設定 */
+@media (min-width: 768px) {
+    .new-pentagon-radar-chart-container {
+        /* カード全体の幅の50%を超えない、かつ300pxを超えないように制限 */
+        max-width: 300px;
+        margin: 0 auto; /* 中央寄せ */
+    }
+}
+
+@media (min-width: 768px) {
+    .product-info-area {
+        /* PC: 幅を親要素の50%に設定 */
+        width: 50%;
+    }
+}
+
+/* 5. レーダーチャートのコンテナと見切れ対策 */
+/* PC幅以上 (md: 768px 以上を想定) */
+@media (min-width: 768px) {
+    .new-pentagon-radar-chart-container {
+        /* ★修正点4: 最大幅を情報エリアの100%に制限し、はみ出しを防ぐ */
+        max-width: 100%;
+        
+        /* Chart.js のキャンバスが固定幅を持つ場合があるため、オーバーライド */
+        /* 情報エリアからパディングを引いた幅を最大値とする */
+        width: min(300px, 100%); 
+        margin: 0 auto; 
+    }
+}
+/* -------------------------------------- */

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,0 +1,5 @@
+class ProductsController < ApplicationController
+  def index
+    @products = Product.all
+  end
+end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,4 +2,21 @@ class ProductsController < ApplicationController
   def index
     @products = Product.all
   end
+
+  private
+
+  def product_params
+    params.require(:product).permit(
+      :name,
+      :country_of_origin,
+      :volume,
+      :reference_price,
+      :sweet_rating,
+      :spicy_rating,
+      :bitter_rating,
+      :green_rating,
+      :fruity_rating,
+      images: []
+    )
+  end
 end

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -1,0 +1,2 @@
+module ProductsHelper
+end

--- a/app/models/olive_variety.rb
+++ b/app/models/olive_variety.rb
@@ -1,0 +1,4 @@
+class OliveVariety < ApplicationRecord
+  has_many :product_olive_varieties, dependent: :destroy
+  has_many :products, through: :product_olive_varieties
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,0 +1,5 @@
+class Product < ApplicationRecord
+  has_many :product_olive_varieties, dependent: :destroy
+  has_many :olive_varieties, through: :product_olive_varieties
+  has_many :posts
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -2,4 +2,5 @@ class Product < ApplicationRecord
   has_many :product_olive_varieties, dependent: :destroy
   has_many :olive_varieties, through: :product_olive_varieties
   has_many :posts
+  has_many_attached :images
 end

--- a/app/models/product_olive_variety.rb
+++ b/app/models/product_olive_variety.rb
@@ -1,0 +1,4 @@
+class ProductOliveVariety < ApplicationRecord
+  belongs_to :product
+  belongs_to :olive_variety
+end

--- a/app/views/posts/_radar_chart.html.erb
+++ b/app/views/posts/_radar_chart.html.erb
@@ -2,7 +2,6 @@
   <canvas id="chart-<%= post.id %>"></canvas>
 </div>
 
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
 document.addEventListener("DOMContentLoaded", function() {
   const ctx = document.getElementById('chart-<%= post.id %>').getContext('2d');

--- a/app/views/products/_radar_chart.html.erb
+++ b/app/views/products/_radar_chart.html.erb
@@ -1,0 +1,44 @@
+<div>
+  <canvas id="chart-<%= product.id %>"></canvas>
+</div>
+
+<script>
+document.addEventListener("DOMContentLoaded", function() {
+  const ctx = document.getElementById('chart-<%= product.id %>').getContext('2d');
+  
+  new Chart(ctx, {
+    type: 'radar',
+    data: {
+      labels: ['甘み', '辛み', '青い', 'フルーティー', '苦み'],
+      datasets: [{
+        label: 'Flavor Chart', 
+        data: [<%= product.sweet_rating %>, <%= product.spicy_rating %>, <%= product.green_rating %>, <%= product.fruity_rating %>, <%= product.bitter_rating %>],
+        fill: true,
+        backgroundColor: 'rgba(54, 162, 235, 0.2)',
+        borderColor: 'rgba(54, 162, 235, 1)',
+        pointBackgroundColor: 'rgba(54, 162, 235, 1)'
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          display: true,
+          labels: {
+            usePointStyle: false,  // 左の四角を非表示
+            boxWidth: 0,           // 余白も消す
+            font: {
+              size: 14,            // 文字サイズ
+              style: 'italic'      // 斜体
+            }
+          }
+        }
+      },
+      scales: {
+        r: { min: 0, max: 5, ticks: { stepSize: 1 } }
+      }
+    }
+  });
+});
+</script>

--- a/app/views/products/_radar_chart.html.erb
+++ b/app/views/products/_radar_chart.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <canvas id="chart-<%= product.id %>"></canvas>
+  <canvas id="chart-<%= product.id %>" class="radar-chart"></canvas>
 </div>
 
 <script>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,5 +1,4 @@
-<div class="my-card">
-  <%= render "shared/floating_button" %>
+<%= render "shared/floating_button" %>
   <h1>商品一覧</h1>
 
   <ul>
@@ -12,4 +11,3 @@
       </li>
     <% end %>        
   </ul>
-</div>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,24 +1,27 @@
 <%= render "shared/floating_button" %>
   <h1>商品一覧</h1>
 
-  <ul>
+  <ul class="product-list-container">
     <% @products.each do |product| %>
-      <li>
-        <div>
-          <% if product.images.attached? %>
-            <% if product.images.size == 1 %>
-              <%= image_tag product.images.first %>
-            <% else %>
-              <%= image_tag product.images.last %>
-            <% end %>
-          <% else %>
-            <div>画像はありません</div>
-          <% end %>
-        </div>
+      <li class="product-card">
 
-        <div>
-          <h2><%= product.name %></h2>
-          <%= render partial: "products/radar_chart", locals: { product: product } %>
+        <div class="product-card-inner"> 
+
+          <div class="product-image-area">
+            <% if product.images.attached? %>
+              <% image_to_show = product.images.size == 1 ? product.images.first : product.images.last %>
+              <%= image_tag image_to_show, class: "product-image" %> 
+            <% else %>
+              <%= image_tag "https://placehold.co/600x400/CCCCCC/000000?text=NO+IMAGE", alt: "画像なし", class: "product-image" %>
+            <% end %>
+          </div>
+
+          <div class="product-info-area">
+            <h2><%= product.name %></h2>
+            <div class="new-pentagon-radar-chart-container">
+              <%= render partial: "products/radar_chart", locals: { product: product } %>
+            </div>
+          </div>
         </div>
       </li>
     <% end %>        

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -5,8 +5,20 @@
     <% @products.each do |product| %>
       <li>
         <div>
+          <% if product.images.attached? %>
+            <% if product.images.size == 1 %>
+              <%= image_tag product.images.first %>
+            <% else %>
+              <%= image_tag product.images.last %>
+            <% end %>
+          <% else %>
+            <div>画像はありません</div>
+          <% end %>
+        </div>
+
+        <div>
           <h2><%= product.name %></h2>
-          <%= render partial: "radar_chart", locals: { product: product } %>
+          <%= render partial: "products/radar_chart", locals: { product: product } %>
         </div>
       </li>
     <% end %>        

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -7,7 +7,7 @@
       <li>
         <div>
           <h2><%= product.name %></h2>
-          <%# render partial: "radar_chart", locals: { product: product } %>
+          <%= render partial: "radar_chart", locals: { product: product } %>
         </div>
       </li>
     <% end %>        

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,0 +1,15 @@
+<div class="my-card">
+  <%= render "shared/floating_button" %>
+  <h1>商品一覧</h1>
+
+  <ul>
+    <% @products.each do |product| %>
+      <li>
+        <div>
+          <h2><%= product.name %></h2>
+          <%# render partial: "radar_chart", locals: { product: product } %>
+        </div>
+      </li>
+    <% end %>        
+  </ul>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,5 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "posts#index"
   resources :posts, only: [ :index, :show, :new, :create ]
+  resources :products, only: [ :index ]
 end

--- a/db/migrate/20251004064356_create_products.rb
+++ b/db/migrate/20251004064356_create_products.rb
@@ -1,0 +1,17 @@
+class CreateProducts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :products do |t|
+      t.string :name
+      t.string :country_of_origin
+      t.integer :volume
+      t.decimal :reference_price
+      t.integer :sweet_rating
+      t.integer :spicy_rating
+      t.integer :bitter_rating
+      t.integer :green_rating
+      t.integer :fruity_rating
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251004064443_create_olive_varieties.rb
+++ b/db/migrate/20251004064443_create_olive_varieties.rb
@@ -1,0 +1,9 @@
+class CreateOliveVarieties < ActiveRecord::Migration[8.0]
+  def change
+    create_table :olive_varieties do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251004064456_create_product_olive_varieties.rb
+++ b/db/migrate/20251004064456_create_product_olive_varieties.rb
@@ -1,0 +1,10 @@
+class CreateProductOliveVarieties < ActiveRecord::Migration[8.0]
+  def change
+    create_table :product_olive_varieties do |t|
+      t.integer :product_id
+      t.integer :olive_variety_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_28_113912) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_04_064456) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -42,6 +42,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_28_113912) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "olive_varieties", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "posts", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "product_id"
@@ -50,6 +56,27 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_28_113912) do
     t.integer "taste_rating"
     t.integer "price_rating"
     t.string "body"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "product_olive_varieties", force: :cascade do |t|
+    t.integer "product_id"
+    t.integer "olive_variety_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "products", force: :cascade do |t|
+    t.string "name"
+    t.string "country_of_origin"
+    t.integer "volume"
+    t.decimal "reference_price"
+    t.integer "sweet_rating"
+    t.integer "spicy_rating"
+    t.integer "bitter_rating"
+    t.integer "green_rating"
+    t.integer "fruity_rating"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -92,3 +92,29 @@ post5.images.attach(io: file1, filename: "sample4_1.jpg", content_type: "image/j
 post5.images.attach(io: file2, filename: "sample4_2.jpg", content_type: "image/jpg")
 post5.images.attach(io: file3, filename: "sample4_3.jpg", content_type: "image/jpg")
 post5.images.attach(io: file4, filename: "sample4_4.jpg", content_type: "image/jpg")
+
+# Product.destroy_all
+
+product1 = Product.create!(
+  name: "商品:オリーブオイル",
+  country_of_origin: "スペイン",
+  volume: 250,
+  reference_price: 2000,
+  sweet_rating: 4,
+  spicy_rating: 3,
+  bitter_rating: 5,
+  green_rating: 4,
+  fruity_rating: 2
+)
+
+product2 = Product.create!(
+  name: "商品:オリーブオイル",
+  country_of_origin: "イタリア",
+  volume: 250,
+  reference_price: 1500,
+  sweet_rating: 3,
+  spicy_rating: 1,
+  bitter_rating: 4,
+  green_rating: 5,
+  fruity_rating: 3
+)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -38,6 +38,7 @@ post2 = Post.create!(
   taste_rating: 2,
   price_rating: 5
 )
+
 file2 = URI.open("https://picsum.photos/301") # 画像URLを変えると別の画像が取れる
 post2.images.attach(io: file2, filename: "sample2.jpg", content_type: "image/jpg")
 
@@ -93,10 +94,13 @@ post5.images.attach(io: file2, filename: "sample4_2.jpg", content_type: "image/j
 post5.images.attach(io: file3, filename: "sample4_3.jpg", content_type: "image/jpg")
 post5.images.attach(io: file4, filename: "sample4_4.jpg", content_type: "image/jpg")
 
-# Product.destroy_all
+# ----------------------
+# 商品サンプルデータ
+# ----------------------
+Product.destroy_all
 
 product1 = Product.create!(
-  name: "商品:オリーブオイル",
+  name: "商品:オリーブオイルA",
   country_of_origin: "スペイン",
   volume: 250,
   reference_price: 2000,
@@ -108,7 +112,7 @@ product1 = Product.create!(
 )
 
 product2 = Product.create!(
-  name: "商品:オリーブオイル",
+  name: "商品:オリーブオイルB",
   country_of_origin: "イタリア",
   volume: 250,
   reference_price: 1500,
@@ -118,3 +122,48 @@ product2 = Product.create!(
   green_rating: 5,
   fruity_rating: 3
 )
+
+file1 = URI.open("https://picsum.photos/300?random=2")
+file2 = URI.open("https://picsum.photos/300?random=3")
+product2.images.attach(io: file1, filename: "sample2_1.jpg", content_type: "image/jpg")
+product2.images.attach(io: file2, filename: "sample2_2.jpg", content_type: "image/jpg")
+
+product3 = Product.create!(
+  name: "商品:オリーブオイルC",
+  country_of_origin: "ポルトガル",
+  volume: 260,
+  reference_price: 1400,
+  sweet_rating: 3,
+  spicy_rating: 2,
+  bitter_rating: 3,
+  green_rating: 5,
+  fruity_rating: 5
+)
+
+file1 = URI.open("https://picsum.photos/300?random=4")
+file2 = URI.open("https://picsum.photos/300?random=5")
+file3 = URI.open("https://picsum.photos/300?random=6")
+product3.images.attach(io: file1, filename: "sample3_1.jpg", content_type: "image/jpg")
+product3.images.attach(io: file2, filename: "sample3_2.jpg", content_type: "image/jpg")
+product3.images.attach(io: file3, filename: "sample3_3.jpg", content_type: "image/jpg")
+
+product4 = Product.create!(
+  name: "商品:オリーブオイルD",
+  country_of_origin: "トルコ",
+  volume: 600,
+  reference_price: 2300,
+  sweet_rating: 4,
+  spicy_rating: 1,
+  bitter_rating: 2,
+  green_rating: 3,
+  fruity_rating: 5
+)
+
+file1 = URI.open("https://picsum.photos/300?random=7")
+file2 = URI.open("https://picsum.photos/300?random=8")
+file3 = URI.open("https://picsum.photos/300?random=9")
+file4 = URI.open("https://picsum.photos/300?random=10")
+product4.images.attach(io: file1, filename: "sample4_1.jpg", content_type: "image/jpg")
+product4.images.attach(io: file2, filename: "sample4_2.jpg", content_type: "image/jpg")
+product4.images.attach(io: file3, filename: "sample4_3.jpg", content_type: "image/jpg")
+product4.images.attach(io: file4, filename: "sample4_4.jpg", content_type: "image/jpg")

--- a/test/controllers/products_controller_test.rb
+++ b/test/controllers/products_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ProductsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/olive_varieties.yml
+++ b/test/fixtures/olive_varieties.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/fixtures/product_olive_varieties.yml
+++ b/test/fixtures/product_olive_varieties.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  product_id: 1
+  olive_variety_id: 1
+
+two:
+  product_id: 1
+  olive_variety_id: 1

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -1,0 +1,23 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  country_of_origin: MyString
+  volume: 1
+  reference_price: 9.99
+  sweet_rating: 1
+  spicy_rating: 1
+  bitter_rating: 1
+  green_rating: 1
+  fruity_rating: 1
+
+two:
+  name: MyString
+  country_of_origin: MyString
+  volume: 1
+  reference_price: 9.99
+  sweet_rating: 1
+  spicy_rating: 1
+  bitter_rating: 1
+  green_rating: 1
+  fruity_rating: 1

--- a/test/models/olive_variety_test.rb
+++ b/test/models/olive_variety_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class OliveVarietyTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/product_olive_variety_test.rb
+++ b/test/models/product_olive_variety_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ProductOliveVarietyTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ProductTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
・2カラムのカードをpc版では横に3個ずつならべるが、この処理で手間取った。
レーダーチャートを160×160 pxにしてかなり縮小。また左寄せになるところ中央寄せにするスタイルを適用したが、これは投稿ページでのレイアウトでも使えるかもしれない。