### PR TITLE
メールサーバーをSendgridに設定

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,14 +92,14 @@ Rails.application.configure do
   # SMTP(メール送信の標準プロトコル)サーバーを使って送信するという宣言.環境変数は.envからも確認できる
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address: "smtp.gmail.com",
+    address: "smtp.sendgrid.net",
     port: 587,
-    domain: "gmail.com",
+    # deviseでも記載している存在しないアドレス
+    domain: "olive-base.onrender.com",
     # フルメールアドレス
-    user_name: ENV["GMAIL_USERNAME"],
-    # アプリパスワード。Rails(アプリ)側がGoogleアカウントにアクセスするときに用いる
-    # Rails側が提示する値（アプリパスワード）と、Google側で作った値が一致すればアクセス許可
-    password: ENV["GMAIL_PASSWORD"],
+    user_name: "apikey",
+    # SendGridで作成したAPIキー/.envにも記載した
+    password: ENV["SENDGRID_API_KEY"],
     authentication: :plain,
     enable_starttls_auto: true
   }


### PR DESCRIPTION
メール設定を行いgmailアドレスを設定。パスワードリセットを試す。結果メール送信時に Gmail の SMTP に接続できず時間切れ。なんでもRenderの無料プランでは、ポート25、465、587を介したアウトバウンドネットワークトラフィック（通常SMTPに使用されるポート）の送信が禁止されています。だそうだ。
メールサーバー(代替サーバー？)をSendgridに変更プルリクエストを出す

mainのプッシュでしかデプロイされないから毎度プルリクエストを作成。マージしているが同じブランチ名で何度もプルリクエストをだしてcloseするというのはあまり推奨されない行動だろうか？